### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.75"
 ring = { version = "0.17.8", default-features = false }
 
 anyhow = { version = "1.0", default-features = false, features = ["std"] }
-async-nats = { version = "0.45", default-features = false, features = ["ring"] }
+async-nats = { version = "0.48", default-features = false, features = ["ring"] }
 async-trait = { version = "0.1.80", default-features = false }
 base64 = { version = "0.22", default-features = false }
 bytes = { version = "1.10", default-features = false }
@@ -45,7 +45,7 @@ tracing = { version = "0.1.30", default-features = false }
 thiserror = { version = "1.0", default-features = false }
 urlencoding = { version = "2.1", default-features = false }
 rustc-hash = { version = "2.1", default-features = false, features = ["std"] }
-time = { version = "0.3.38", default-features = false }
+time = { version = "0.3.38", default-features = false, features = ["std"] }
 once_cell = { version = "1.19.0", default-features = false }
 
 [dev-dependencies]

--- a/tests/consumer/dh_consumer.rs
+++ b/tests/consumer/dh_consumer.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Weidmueller Interface GmbH & Co. KG <oss@weidmueller.com>
 //
 // SPDX-License-Identifier: MIT
+#![allow(clippy::large_futures)]
 
 use std::{sync::Arc, time::Duration};
 

--- a/tests/consumer/dh_provider_con.rs
+++ b/tests/consumer/dh_provider_con.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Weidmueller Interface GmbH & Co. KG <oss@weidmueller.com>
 //
 // SPDX-License-Identifier: MIT
+#![allow(clippy::large_futures)]
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 


### PR DESCRIPTION
- update to async-nats 0.48
- allow clippy warning about large_futures in tests